### PR TITLE
Bigger image.

### DIFF
--- a/albumcolors.js
+++ b/albumcolors.js
@@ -104,6 +104,8 @@
 		var canvas, context;
 
 		canvas = document.createElement('canvas');
+		canvas.width = this.image.width;
+		canvas.height = this.image.height;
 		context = canvas.getContext('2d');
 
 		context.drawImage(this.image, 0, 0);


### PR DESCRIPTION
According to the w3c specs for the canvas element, it defaults to a
width of 300px and height of 150 px. This causes any image which excedes
these limits to return black pxiels for those regions outside of this
boundary.

http://www.w3.org/TR/2012/WD-html5-author-20120329/the-canvas-element.html#the-canvas-element

This fix sets the width and height of the canvas before drawing the image. Allowing albumcolors to properly analyse the image.
