### PR TITLE
Fix for cached images

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,17 @@ The algorithm is simple.
 ## Limitations
 
 Images are loaded through `canvas`, therefore we are limited to the same origin rule. In the last.fm example, a simple image proxy is included to bypass the issue.
-	
+
+## Using images with CORS headers
+
+If you want to use images from other domains (eg. asset domains), you can still use AlbumColors.js, but with one minor addition to the code. 
+You will need to add the following line to the `AlbumImage.prototype.fetch` function, right after the `new Image()`:
+
+	this.image.crossOrigin = "anonymous";
+
+Also make sure you have set the right headers on the image you are trying to fetch. 
+[More info](http://enable-cors.org/server.html) on setting the right headers for using CORS.
+
 ## License
 
 [University of Illinois / NCSA](http://opensource.org/licenses/NCSA)

--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ Images are loaded through `canvas`, therefore we are limited to the same origin 
 
 ## Using images with CORS headers
 
-If you want to use images from other domains (eg. asset domains), you can still use AlbumColors.js, but with one minor addition to the code. 
-You will need to add the following line to the `AlbumImage.prototype.fetch` function, right after the `new Image()`:
+If you want to use images from other domains (eg. asset domains), pass along `{enableCORS: true}` as a second argument to the new instance of `AlbumColors`. 
+AlbumColors with CORS support enabled will not work in IE9 since it does not support CORS headers for images (only XDomainRequest for XHR requests). 
 
-	this.image.crossOrigin = "anonymous";
+Example with `enableCORS` set to `true`:
 
-Also make sure you have set the right headers on the image you are trying to fetch. 
+	new AlbumColors(url_to_image, {enableCORS: true});
+
+Don't forget: Make sure you have set the right headers on the image you are trying to fetch. 
 [More info](http://enable-cors.org/server.html) on setting the right headers for using CORS.
 
 ## License

--- a/albumcolors.js
+++ b/albumcolors.js
@@ -94,6 +94,11 @@
 		};
 
 		this.image.src = this.url;
+
+		if (this.image.complete || this.image.complete === undefined) {
+			this.image.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+			this.image.src = this.url;
+		}
 	};
 
 	AlbumImage.prototype.getCanvas = function() {

--- a/albumcolors.js
+++ b/albumcolors.js
@@ -78,7 +78,8 @@
 	 * A Class for the to wrap image,
 	 * used for counting raw color pixels
 	 */
-	AlbumImage = function(url) {
+	AlbumImage = function(url, options) {
+		this.options = options;
 		this.url = url;
 	};
 
@@ -86,6 +87,10 @@
 		var that = this;
 
 		this.image = new Image();
+
+		if (this.options.enableCORS) {
+			this.image.crossOrigin = "anonymous";
+		}
 
 		this.image.onload = function() {
 			if (callback) {
@@ -143,9 +148,10 @@
 	 * AlbumColors
 	 * Generate pallete among dominating colors
 	 */
-	AlbumColors = function(imageUrl) {
+	AlbumColors = function(imageUrl, options) {
+		this.options = options || {};
 		this.imageUrl = imageUrl;
-		this.image = new AlbumImage(imageUrl);
+		this.image = new AlbumImage(imageUrl, this.options);
 	};
 
 	AlbumColors.prototype.getColors = function(callback) {


### PR DESCRIPTION
This fixes the 'onload' event for cached images. Used example from this webkit hack
http://groups.google.com/group/jquery-dev/browse_thread/thread/eee6ab7b2
da50e1f
